### PR TITLE
better detection of the Unity executable when it's been installed somewhere non-standard

### DIFF
--- a/Util.cs
+++ b/Util.cs
@@ -85,6 +85,26 @@ namespace MonoDevelop.Debugger.Soft.Unity
 			} else if (Platform.IsWindows) {
 				unityLocation = (File.Exists (unityWinX86)? unityWinX86: unityWin);
 			} 
+
+			// If Unity isn't installed to its default location then another strategy is needed.
+			// Next best option is to guess based on where MonoDevelop is running, as it's
+			// installed side-by-side with Unity.
+			if(string.IsNullOrEmpty(unityLocation) || !File.Exists (unityLocation))
+			{
+				string mdLocation = System.Reflection.Assembly.GetEntryAssembly().Location;
+
+				string sxsPath = string.Empty;
+				if(Platform.IsMac && mdLocation.Contains ("MonoDevelop.app")) {
+					// Go back up to where the application bundle is and look for a Unity.app bundle alongside it
+					sxsPath = mdLocation.Substring(0, mdLocation.LastIndexOf("MonoDevelop.app")) + "Unity.app/Contents/MacOS/Unity";
+				} else if(Platform.IsWindows) {
+					// Strip the "MonoDevelop/bin/MonoDevelop.exe" from the end of the path
+					sxsPath = mdLocation.Substring (0, mdLocation.Length - "MonoDevelop/bin/MonoDevelop.exe".Length) + @"Editor\Unity.exe";
+				}
+
+				if(!String.IsNullOrEmpty(sxsPath) && File.Exists (sxsPath))
+					unityLocation = sxsPath;
+			}
 			
 			return unityLocation;
 		}


### PR DESCRIPTION
At the moment the MD debugging plugin appears to always assume that Unity's been installed at the default path, and a bunch of things break when it isn't (can't launch Unity from MD, looks like tracepoints and conditional breakpoints stop working too, etc). For someone like me, who has a bunch of separate Unity installs in different-versioned folders but no canonical one, it's a problem.

This patch implements a second strategy for locating the Unity executable if there isn't one present at the default path, by looking for the Unity install that is side-by-side with the executing MonoDevelop.

I haven't actually managed to get this working with a shipped MD yet - dropping it inside the bundle in the appropriate place was definitely getting run but the wrong path was still showing up in the preferences file. It appeared to be working with the MD that I built from source (though there was no MonoDevelop.app in its path so I couldn't test it _properly_).

Still, this has got to be _some_ part of the solution, right?
