### PR TITLE
Update PlayerConnection.cs

### DIFF
--- a/PlayerConnection.cs
+++ b/PlayerConnection.cs
@@ -43,7 +43,7 @@ namespace MonoDevelop.Debugger.Soft.Unity
 	/// </summary>
 	public class PlayerConnection
 	{
-		public static readonly int[] PLAYER_MULTICAST_PORTS = new[]{ 54997, 34997, 57997 };
+		public static readonly int[] PLAYER_MULTICAST_PORTS = new[]{ 54997, 34997, 57997, 58997 };
 		public const string PLAYER_MULTICAST_GROUP = "225.0.0.222";
 		public const int MAX_LAST_SEEN_ITERATIONS = 3;
 		


### PR DESCRIPTION
[Xbox One] Adding port that XB1 uses to connection list

```
* XB1 uses 58997 for multicast.  I believe 57997 was already in the list
  for the XB1, and that might have just been a type-o.  I'm not certain
  about that though, so I left in the list incase anyone else is using it.
```
