### PR TITLE
Decouple MonoDevelop dependencies from Unity Process Discovery

### DIFF
--- a/Log.cs
+++ b/Log.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace MonoDevelop.Debugger.Soft.Unity
+{
+	public static class Log
+	{
+		public interface ILogger
+		{
+			void Info (string message);
+			void Warning (string message, Exception e);
+			void Error (string message, Exception e);
+		}
+
+		static List<ILogger> loggers = new List<ILogger>();
+
+		public static void AddLogger(ILogger logger)
+		{
+			loggers.Add (logger);
+		}
+
+		public static void Info(string message)
+		{
+			foreach (var logger in loggers)
+				logger.Info (message);
+		}
+
+		public static void Warning(string message, Exception e)
+		{
+			foreach (var logger in loggers)
+				logger.Warning (message, e);
+		}
+
+		public static void Error(string message, Exception e)
+		{
+			foreach (var logger in loggers)
+				logger.Error (message, e);
+		}
+	}
+}
+

--- a/MonoDevelop.Debugger.Soft.Unity.csproj
+++ b/MonoDevelop.Debugger.Soft.Unity.csproj
@@ -17,7 +17,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\monodevelop\main\build\AddIns\MonoDevelop.Debugger.Soft.Unity</OutputPath>
-    <DefineConstants>DEBUG</DefineConstants>
+    <DefineConstants>DEBUG;UNITY_IOS_USB_ATTACH</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CustomCommands>
@@ -34,6 +34,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <DefineConstants>UNITY_IOS_USB_ATTACH</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -97,6 +98,8 @@
     <Compile Include="gtk-gui\MonoDevelop.Debugger.Soft.Unity.GeneralOptionsPanel.cs" />
     <Compile Include="Util.cs" />
     <Compile Include="PlayerConnection.cs" />
+    <Compile Include="UnityProcessDiscovery.cs" />
+    <Compile Include="UnityProcessInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>

--- a/MonoDevelop.Debugger.Soft.Unity.csproj
+++ b/MonoDevelop.Debugger.Soft.Unity.csproj
@@ -100,6 +100,7 @@
     <Compile Include="PlayerConnection.cs" />
     <Compile Include="UnityProcessDiscovery.cs" />
     <Compile Include="UnityProcessInfo.cs" />
+    <Compile Include="UnityAttachInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>

--- a/MonoDevelop.Debugger.Soft.Unity.csproj
+++ b/MonoDevelop.Debugger.Soft.Unity.csproj
@@ -17,7 +17,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\monodevelop\main\build\AddIns\MonoDevelop.Debugger.Soft.Unity</OutputPath>
-    <DefineConstants>DEBUG;UNITY_IOS_USB_ATTACH</DefineConstants>
+    <DefineConstants>DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CustomCommands>
@@ -34,7 +34,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <DefineConstants>UNITY_IOS_USB_ATTACH</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -101,6 +100,8 @@
     <Compile Include="UnityProcessDiscovery.cs" />
     <Compile Include="UnityProcessInfo.cs" />
     <Compile Include="UnityAttachInfo.cs" />
+    <Compile Include="Platform.cs" />
+    <Compile Include="Log.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>

--- a/Platform.cs
+++ b/Platform.cs
@@ -1,0 +1,21 @@
+﻿namespace MonoDevelop.Debugger.Soft.Unity
+{
+	public static class Platform
+	{
+		public static bool IsLinux
+		{
+			get { return MonoDevelop.Core.Platform.IsLinux; }
+		}
+
+		public static bool IsMac
+		{
+			get { return MonoDevelop.Core.Platform.IsMac; }
+		}
+
+		public static bool IsWindows
+		{
+			get { return MonoDevelop.Core.Platform.IsWindows; }
+		}
+	}
+}
+

--- a/PlayerConnection.cs
+++ b/PlayerConnection.cs
@@ -30,8 +30,6 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Sockets;
-using System.IO;
-using System.Runtime.InteropServices;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Text.RegularExpressions;

--- a/UnityAttachInfo.cs
+++ b/UnityAttachInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Net;
+
+namespace MonoDevelop.Debugger.Soft.Unity
+{
+	public class UnityAttachInfo
+	{
+		public string AppName { get; private set; }
+		public IPAddress Address { get; private set; }
+		public int Port { get; private set; }
+
+		public UnityAttachInfo (string appName, IPAddress address, int port)
+		{
+			AppName = appName;
+			Address = address;
+			Port = port;
+		}
+	}
+}
+

--- a/UnityProcessDiscovery.cs
+++ b/UnityProcessDiscovery.cs
@@ -8,12 +8,6 @@ namespace MonoDevelop.Debugger.Soft.Unity
 {
 	public static class UnityProcessDiscovery
 	{
-		public interface ILogger
-		{
-			void Log (string message);
-		}
-
-		static List<ILogger> loggers = new List<ILogger>();
 		static readonly PlayerConnection unityPlayerConnection;
 
 		static List<UnityProcessInfo> usbProcesses = new List<UnityProcessInfo>();
@@ -51,19 +45,8 @@ namespace MonoDevelop.Debugger.Soft.Unity
 			} 
 			catch (Exception e)
 			{
-				Log ("Error launching player connection discovery service: Unity player discovery will be unavailable\n" + e);
+				Log.Error ("Error launching player connection discovery service: Unity player discovery will be unavailable", e);
 			}
-		}
-
-		static void Log(string message)
-		{
-			foreach (var logger in loggers)
-				logger.Log (message);
-		}
-
-		public static void AddLogger(ILogger logger)
-		{
-			loggers.Add (logger);
 		}
 
 		public static void Stop()
@@ -210,20 +193,18 @@ namespace MonoDevelop.Debugger.Soft.Unity
 		{
 			var processes = new List<UnityProcessInfo>();
 
-			#if UNITY_IOS_USB_ATTACH
 			try
 			{
 				iOSDevices.GetUSBDevices (ConnectorRegistry, processes);
 			}
 			catch(NotSupportedException)
 			{
-				Log("iOS over USB not supported on this platform");
+				Log.Info("iOS over USB not supported on this platform");
 			}
 			catch(Exception e)
 			{
-				Log("iOS USB Error: " + e);
+				Log.Info("iOS USB Error: " + e);
 			}
-			#endif
 
 			return processes;
 		}

--- a/UnityProcessDiscovery.cs
+++ b/UnityProcessDiscovery.cs
@@ -137,7 +137,7 @@ namespace MonoDevelop.Debugger.Soft.Unity
 			if (systemProcesses != null) {
 				foreach (Process p in systemProcesses) {
 					try {
-						if ((p.ProcessName.StartsWith ("unity", comparison) ||
+						if (((p.ProcessName.StartsWith ("unity", comparison) && !p.ProcessName.StartsWith ("unity-", comparison)) ||
 							p.ProcessName.Contains ("Unity.app")) &&
 							!p.ProcessName.Contains ("UnityDebug") &&
 							!p.ProcessName.Contains ("UnityShader") &&

--- a/UnityProcessDiscovery.cs
+++ b/UnityProcessDiscovery.cs
@@ -101,7 +101,7 @@ namespace MonoDevelop.Debugger.Soft.Unity
 					// Direct USB devices
 					lock(usbLock)
 					{
-						var usbThreadProcesses = GetUnityiOSUsbProcesses();
+						usbProcesses = GetUnityiOSUsbProcesses();
 						usbProcessesFinished = true;
 					}
 				});

--- a/UnityProcessDiscovery.cs
+++ b/UnityProcessDiscovery.cs
@@ -156,6 +156,7 @@ namespace MonoDevelop.Debugger.Soft.Unity
 					try {
 						if ((p.ProcessName.StartsWith ("unity", comparison) ||
 							p.ProcessName.Contains ("Unity.app")) &&
+							!p.ProcessName.Contains ("UnityDebug") &&
 							!p.ProcessName.Contains ("UnityShader") &&
 							!p.ProcessName.Contains ("UnityHelper") &&
 							!p.ProcessName.Contains ("Unity Helper")) {

--- a/UnityProcessDiscovery.cs
+++ b/UnityProcessDiscovery.cs
@@ -16,11 +16,9 @@ namespace MonoDevelop.Debugger.Soft.Unity
 		static List<ILogger> loggers = new List<ILogger>();
 		static readonly PlayerConnection unityPlayerConnection;
 
-		#if UNITY_IOS_USB_ATTACH
 		static List<UnityProcessInfo> usbProcesses = new List<UnityProcessInfo>();
 		static bool usbProcessesFinished = true;
 		static object usbLock = new object();
-		#endif
 
 		static List<UnityProcessInfo> unityProcesses = new List<UnityProcessInfo> ();
 
@@ -73,69 +71,28 @@ namespace MonoDevelop.Debugger.Soft.Unity
 			run = false;
 		}
 
-		public static UnityProcessInfo[] GetAttachableProcesses ()
+		public static UnityProcessInfo[] GetAttachableProcessesAsync ()
 		{
-			int index = 1;
 			List<UnityProcessInfo> processes = new List<UnityProcessInfo> ();
 
-			StringComparison comparison = StringComparison.OrdinalIgnoreCase;
+			// Get players
+			processes.AddRange (GetUnityPlayerProcesses (false));
 
-			if (null != unityPlayerConnection) {
-				if(Monitor.TryEnter (unityPlayerConnection)) {
-					try {
-						foreach (string player in unityPlayerConnection.AvailablePlayers) {
-							try {
-								PlayerConnection.PlayerInfo info = PlayerConnection.PlayerInfo.Parse (player);
-								if (info.m_AllowDebugging) {
-									UnityPlayers[info.m_Guid] = info;
-									processes.Add (new UnityProcessInfo (info.m_Guid, info.m_Id));
-									++index;
-								}
-							} catch {
-								// Don't care; continue
-							}
-						}
-					}
-					finally {
-						Monitor.Exit (unityPlayerConnection);
-					}
-				}
-			}
-
+			// Get editor
 			if (unityProcessesFinished) 
 			{
 				unityProcessesFinished = false;
 
-				ThreadPool.QueueUserWorkItem (delegate {
-
-					Process[] systemProcesses = Process.GetProcesses();
-					var unityThreadProcesses = new List<UnityProcessInfo>();
-
-					if(systemProcesses != null)
-					{
-						foreach (Process p in systemProcesses) {
-							try {
-								if ((p.ProcessName.StartsWith ("unity", comparison) ||
-									p.ProcessName.Contains ("Unity.app")) &&
-									!p.ProcessName.Contains ("UnityShader") &&
-									!p.ProcessName.Contains ("UnityHelper") &&
-									!p.ProcessName.Contains ("Unity Helper")) {
-									unityThreadProcesses.Add (new UnityProcessInfo (p.Id, string.Format ("{0} ({1})", "Unity Editor", p.ProcessName)));
-								}
-							} catch {
-								// Don't care; continue
-							}
-						}
-
-						unityProcesses = unityThreadProcesses;
-						unityProcessesFinished = true;
-					}
+				ThreadPool.QueueUserWorkItem (delegate 
+				{
+					unityProcesses = GetUnityEditorProcesses();
+					unityProcessesFinished = true;
 				});
 			}
 
 			processes.AddRange (unityProcesses);
 
-			#if UNITY_IOS_USB_ATTACH
+			// Get iOS USB
 			if (usbProcessesFinished)
 			{
 				usbProcessesFinished = false;
@@ -144,31 +101,111 @@ namespace MonoDevelop.Debugger.Soft.Unity
 					// Direct USB devices
 					lock(usbLock)
 					{
-						var usbThreadProcesses = new List<UnityProcessInfo>();
-
-						try
-						{
-							iOSDevices.GetUSBDevices (ConnectorRegistry, usbThreadProcesses);
-						}
-						catch(NotSupportedException)
-						{
-							Log("iOS over USB not supported on this platform");
-						}
-						catch(Exception e)
-						{
-							Log("iOS USB Error: " + e);
-						}
-						usbProcesses = usbThreadProcesses;
+						var usbThreadProcesses = GetUnityiOSUsbProcesses();
 						usbProcessesFinished = true;
 					}
 				});
 			}
 
 			processes.AddRange (usbProcesses);
-			#endif
 
 			return processes.ToArray ();
 		}
+
+		public static List<UnityProcessInfo> GetAttachableProcesses ()
+		{
+			List<UnityProcessInfo> processes = new List<UnityProcessInfo> ();
+			processes.AddRange (GetUnityPlayerProcesses (true));
+			processes.AddRange (GetUnityEditorProcesses ());
+			processes.AddRange (GetUnityiOSUsbProcesses ());
+
+			return processes;
+		}
+
+		public static List<UnityProcessInfo> GetUnityEditorProcesses()
+		{
+			StringComparison comparison = StringComparison.OrdinalIgnoreCase;
+
+			Process[] systemProcesses = Process.GetProcesses();
+			var unityEditorProcesses = new List<UnityProcessInfo>();
+
+			if (systemProcesses != null) {
+				foreach (Process p in systemProcesses) {
+					try {
+						if ((p.ProcessName.StartsWith ("unity", comparison) ||
+							p.ProcessName.Contains ("Unity.app")) &&
+							!p.ProcessName.Contains ("UnityShader") &&
+							!p.ProcessName.Contains ("UnityHelper") &&
+							!p.ProcessName.Contains ("Unity Helper")) {
+							unityEditorProcesses.Add (new UnityProcessInfo (p.Id, string.Format ("{0} ({1})", "Unity Editor", p.ProcessName)));
+						}
+					} catch {
+						// Don't care; continue
+					}
+				}
+			}
+
+			return unityEditorProcesses;
+		}
+
+		public static List<UnityProcessInfo> GetUnityPlayerProcesses(bool block)
+		{
+			int index = 1;
+			List<UnityProcessInfo> processes = new List<UnityProcessInfo> ();
+
+			if (null != unityPlayerConnection) 
+			{
+				if (block)
+					Monitor.Enter (unityPlayerConnection);
+				else
+					if(!Monitor.TryEnter(unityPlayerConnection))
+						return processes;
+				try 
+				{
+					foreach (string player in unityPlayerConnection.AvailablePlayers) {
+						try {
+							PlayerConnection.PlayerInfo info = PlayerConnection.PlayerInfo.Parse (player);
+							if (info.m_AllowDebugging) {
+								UnityPlayers[info.m_Guid] = info;
+								processes.Add (new UnityProcessInfo (info.m_Guid, info.m_Id));
+								++index;
+							}
+						} catch {
+							// Don't care; continue
+						}
+					}
+				}
+				finally 
+				{
+					Monitor.Exit (unityPlayerConnection);
+				}
+			}
+
+			return processes;
+		}
+
+		public static List<UnityProcessInfo> GetUnityiOSUsbProcesses()
+		{
+			var processes = new List<UnityProcessInfo>();
+
+			#if UNITY_IOS_USB_ATTACH
+			try
+			{
+				iOSDevices.GetUSBDevices (ConnectorRegistry, processes);
+			}
+			catch(NotSupportedException)
+			{
+				Log("iOS over USB not supported on this platform");
+			}
+			catch(Exception e)
+			{
+				Log("iOS USB Error: " + e);
+			}
+			#endif
+
+			return processes;
+		}
+
 	}
 
 	// Allows to define how to setup and tear down connection for debugger to connect to the

--- a/UnityProcessDiscovery.cs
+++ b/UnityProcessDiscovery.cs
@@ -9,6 +9,14 @@ namespace MonoDevelop.Debugger.Soft.Unity
 {
 	public static class UnityProcessDiscovery
 	{
+		[Flags]
+		public enum GetProcessOptions
+		{
+			Editor = (1 << 0),
+			Players = (1 << 1),
+			All = Editor | Players
+		};
+
 		static readonly PlayerConnection unityPlayerConnection;
 
 		static List<UnityProcessInfo> usbProcesses = new List<UnityProcessInfo>();
@@ -117,12 +125,17 @@ namespace MonoDevelop.Debugger.Soft.Unity
 			return processes.ToArray ();
 		}
 
-		public static List<UnityProcessInfo> GetAttachableProcesses ()
+		public static List<UnityProcessInfo> GetAttachableProcesses (GetProcessOptions options = GetProcessOptions.All)
 		{
 			List<UnityProcessInfo> processes = new List<UnityProcessInfo> ();
-			processes.AddRange (GetUnityPlayerProcesses (true));
-			processes.AddRange (GetUnityEditorProcesses ());
-			processes.AddRange (GetUnityiOSUsbProcesses ());
+
+			if((options & GetProcessOptions.Editor) == GetProcessOptions.Editor)
+				processes.AddRange (GetUnityEditorProcesses ());
+	
+			if ((options & GetProcessOptions.Players) == GetProcessOptions.Players) {
+				processes.AddRange (GetUnityPlayerProcesses (true));
+				processes.AddRange (GetUnityiOSUsbProcesses ());
+			}
 
 			return processes;
 		}

--- a/UnityProcessDiscovery.cs
+++ b/UnityProcessDiscovery.cs
@@ -1,0 +1,220 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Diagnostics;
+
+namespace MonoDevelop.Debugger.Soft.Unity
+{
+	public static class UnityProcessDiscovery
+	{
+		public interface ILogger
+		{
+			void Log (string message);
+		}
+
+		static List<ILogger> loggers = new List<ILogger>();
+		static readonly PlayerConnection unityPlayerConnection;
+
+		#if UNITY_IOS_USB_ATTACH
+		static List<UnityProcessInfo> usbProcesses = new List<UnityProcessInfo>();
+		static bool usbProcessesFinished = true;
+		static object usbLock = new object();
+		#endif
+
+		static List<UnityProcessInfo> unityProcesses = new List<UnityProcessInfo> ();
+
+		static bool unityProcessesFinished = true;
+		static bool run = true;
+
+		internal static Dictionary<uint, PlayerConnection.PlayerInfo> UnityPlayers {
+			get;
+			private set;
+		}
+
+		internal static ConnectorRegistry ConnectorRegistry { get; private set; }
+
+		static UnityProcessDiscovery ()
+		{
+			UnityPlayers = new Dictionary<uint, PlayerConnection.PlayerInfo> ();
+			ConnectorRegistry = new ConnectorRegistry();
+
+			try {
+				// HACK: Poll Unity players
+				unityPlayerConnection = new PlayerConnection ();
+				ThreadPool.QueueUserWorkItem (delegate {
+					while (run) {
+						lock (unityPlayerConnection) {
+							unityPlayerConnection.Poll ();
+						}
+						Thread.Sleep (1000);
+					}
+				});
+			} 
+			catch (Exception e)
+			{
+				Log ("Error launching player connection discovery service: Unity player discovery will be unavailable\n" + e);
+			}
+		}
+
+		static void Log(string message)
+		{
+			foreach (var logger in loggers)
+				logger.Log (message);
+		}
+
+		public static void AddLogger(ILogger logger)
+		{
+			loggers.Add (logger);
+		}
+
+		public static void Stop()
+		{
+			run = false;
+		}
+
+		public static UnityProcessInfo[] GetAttachableProcesses ()
+		{
+			int index = 1;
+			List<UnityProcessInfo> processes = new List<UnityProcessInfo> ();
+
+			StringComparison comparison = StringComparison.OrdinalIgnoreCase;
+
+			if (null != unityPlayerConnection) {
+				if(Monitor.TryEnter (unityPlayerConnection)) {
+					try {
+						foreach (string player in unityPlayerConnection.AvailablePlayers) {
+							try {
+								PlayerConnection.PlayerInfo info = PlayerConnection.PlayerInfo.Parse (player);
+								if (info.m_AllowDebugging) {
+									UnityPlayers[info.m_Guid] = info;
+									processes.Add (new UnityProcessInfo (info.m_Guid, info.m_Id));
+									++index;
+								}
+							} catch {
+								// Don't care; continue
+							}
+						}
+					}
+					finally {
+						Monitor.Exit (unityPlayerConnection);
+					}
+				}
+			}
+
+			if (unityProcessesFinished) 
+			{
+				unityProcessesFinished = false;
+
+				ThreadPool.QueueUserWorkItem (delegate {
+
+					Process[] systemProcesses = Process.GetProcesses();
+					var unityThreadProcesses = new List<UnityProcessInfo>();
+
+					if(systemProcesses != null)
+					{
+						foreach (Process p in systemProcesses) {
+							try {
+								if ((p.ProcessName.StartsWith ("unity", comparison) ||
+									p.ProcessName.Contains ("Unity.app")) &&
+									!p.ProcessName.Contains ("UnityShader") &&
+									!p.ProcessName.Contains ("UnityHelper") &&
+									!p.ProcessName.Contains ("Unity Helper")) {
+									unityThreadProcesses.Add (new UnityProcessInfo (p.Id, string.Format ("{0} ({1})", "Unity Editor", p.ProcessName)));
+								}
+							} catch {
+								// Don't care; continue
+							}
+						}
+
+						unityProcesses = unityThreadProcesses;
+						unityProcessesFinished = true;
+					}
+				});
+			}
+
+			processes.AddRange (unityProcesses);
+
+			#if UNITY_IOS_USB_ATTACH
+			if (usbProcessesFinished)
+			{
+				usbProcessesFinished = false;
+
+				ThreadPool.QueueUserWorkItem (delegate {
+					// Direct USB devices
+					lock(usbLock)
+					{
+						var usbThreadProcesses = new List<UnityProcessInfo>();
+
+						try
+						{
+							iOSDevices.GetUSBDevices (ConnectorRegistry, usbThreadProcesses);
+						}
+						catch(NotSupportedException)
+						{
+							Log("iOS over USB not supported on this platform");
+						}
+						catch(Exception e)
+						{
+							Log("iOS USB Error: " + e);
+						}
+						usbProcesses = usbThreadProcesses;
+						usbProcessesFinished = true;
+					}
+				});
+			}
+
+			processes.AddRange (usbProcesses);
+			#endif
+
+			return processes.ToArray ();
+		}
+	}
+
+	public class ConnectorRegistry
+	{
+		// This is used to map process id <-> unique string id. MonoDevelop attachment is built
+		// around process ids.
+		object processIdLock = new object();
+		uint nextProcessId = 1000000;
+		Dictionary<uint, string> processIdToUniqueId = new Dictionary<uint, string>();
+		Dictionary<string, uint> uniqueIdToProcessId = new Dictionary<string, uint>();
+
+		public Dictionary<uint, IUnityDbgConnector> Connectors { get; private set; }
+
+
+		public uint GetProcessIdForUniqueId(string uid)
+		{
+			lock (processIdLock)
+			{
+				uint processId;
+				if (uniqueIdToProcessId.TryGetValue(uid, out processId))
+					return processId;
+
+				processId = nextProcessId++;
+				processIdToUniqueId.Add(processId, uid);
+				uniqueIdToProcessId.Add(uid, processId);
+
+				return processId;
+			}
+		}
+
+
+		public string GetUniqueIdFromProcessId(uint processId)
+		{
+			lock (processIdLock) {
+				string uid;
+				if (processIdToUniqueId.TryGetValue(processId, out uid))
+					return uid;
+
+				return null;
+			}
+		}
+
+
+		public ConnectorRegistry()
+		{
+			Connectors = new Dictionary<uint, IUnityDbgConnector>();
+		}
+	}
+}
+

--- a/UnityProcessDiscovery.cs
+++ b/UnityProcessDiscovery.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Diagnostics;
 using System.Net;
+using System.Linq;
 
 namespace MonoDevelop.Debugger.Soft.Unity
 {
@@ -178,7 +179,14 @@ namespace MonoDevelop.Debugger.Soft.Unity
 			if (null != unityPlayerConnection) 
 			{
 				if (block)
+				{
 					Monitor.Enter (unityPlayerConnection);
+
+					for (int i = 0; i < 12 && !unityPlayerConnection.AvailablePlayers.Any (); ++i) {
+						unityPlayerConnection.Poll ();
+						Thread.Sleep (250);
+					}
+				}
 				else
 					if(!Monitor.TryEnter(unityPlayerConnection))
 						return processes;

--- a/UnityProcessDiscovery.cs
+++ b/UnityProcessDiscovery.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Diagnostics;
+using Mono.Debugging.Soft;
 
 namespace MonoDevelop.Debugger.Soft.Unity
 {
@@ -168,6 +169,14 @@ namespace MonoDevelop.Debugger.Soft.Unity
 
 			return processes.ToArray ();
 		}
+	}
+
+	// Allows to define how to setup and tear down connection for debugger to connect to the
+	// debugee. For example to setup TCP tunneling over USB.
+	public interface IUnityDbgConnector
+	{
+		SoftDebuggerStartInfo SetupConnection();
+		void OnDisconnect();
 	}
 
 	public class ConnectorRegistry

--- a/UnityProcessDiscovery.cs
+++ b/UnityProcessDiscovery.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Diagnostics;
-using Mono.Debugging.Soft;
 using System.Net;
 
 namespace MonoDevelop.Debugger.Soft.Unity
@@ -72,7 +71,7 @@ namespace MonoDevelop.Debugger.Soft.Unity
 			run = false;
 		}
 
-		public static SoftDebuggerStartInfo GetUnitySoftDebuggerStartInfo(long processId, ref IUnityDbgConnector connector)
+		public static UnityAttachInfo GetUnityAttachInfo(long processId, ref IUnityDbgConnector connector)
 		{
 			if (ConnectorRegistry.Connectors.ContainsKey((uint)processId)) {
 				connector = ConnectorRegistry.Connectors[(uint)processId];
@@ -83,14 +82,14 @@ namespace MonoDevelop.Debugger.Soft.Unity
 					? (int)(56000 + (processId % 1000))
 					: (int)player.m_DebuggerPort);
 				try {
-					return new SoftDebuggerStartInfo (new SoftDebuggerConnectArgs (player.m_Id, player.m_IPEndPoint.Address, (int)port));
+					return new UnityAttachInfo (player.m_Id, player.m_IPEndPoint.Address, (int)port);
 				} catch (Exception ex) {
 					throw new Exception (string.Format ("Unable to attach to {0}:{1}", player.m_IPEndPoint.Address, port), ex);
 				}
 			}
 
 			long defaultPort = 56000 + (processId % 1000);
-			return new SoftDebuggerStartInfo (new SoftDebuggerConnectArgs (null, IPAddress.Loopback, (int)defaultPort));
+			return new UnityAttachInfo (null, IPAddress.Loopback, (int)defaultPort);
 		}
 
 		public static UnityProcessInfo[] GetAttachableProcessesAsync ()
@@ -235,7 +234,7 @@ namespace MonoDevelop.Debugger.Soft.Unity
 	// debugee. For example to setup TCP tunneling over USB.
 	public interface IUnityDbgConnector
 	{
-		SoftDebuggerStartInfo SetupConnection();
+		UnityAttachInfo SetupConnection();
 		void OnDisconnect();
 	}
 

--- a/UnityProcessInfo.cs
+++ b/UnityProcessInfo.cs
@@ -1,0 +1,15 @@
+﻿namespace MonoDevelop.Debugger.Soft.Unity
+{
+	public class UnityProcessInfo
+	{	
+		public long Id { get; set; }
+		public string Name { get; set; }
+
+		public UnityProcessInfo(long id, string name)
+		{
+			Id = id;
+			Name = name;
+		}
+	}
+}
+

--- a/UnityProjectServiceExtension.cs
+++ b/UnityProjectServiceExtension.cs
@@ -43,7 +43,6 @@ namespace MonoDevelop.Debugger.Soft.Unity
 	{
 		internal static string EditLayout = "Solution";
 		private DebuggerEngine unityDebuggerEngine = null;
-		bool processesPolled = false;
 		UnityExecutionCommand executionCommand = new UnityExecutionCommand();
 
 		DebuggerEngine UnityDebuggerEngine
@@ -89,17 +88,6 @@ namespace MonoDevelop.Debugger.Soft.Unity
 		/// </summary>
 		protected override bool CanExecute (SolutionEntityItem item, ExecutionContext context, ConfigurationSelector configuration)
 		{
-			// HACK: Poll for attachable processes so the players processes are available when trying to attach for the first time.
-			if (!processesPolled) {
-				DispatchService.ThreadDispatch (delegate {					
-					// Hack: Poll twice, this increases the chances of iOS USB being ready
-					UnityDebuggerEngine.GetAttachableProcesses ();
-					System.Threading.Thread.Sleep(250);
-					UnityDebuggerEngine.GetAttachableProcesses ();
-				});
-				processesPolled = true;
-			}
-
 			if (context.ExecutionHandler != null)
 				context.ExecutionHandler.CanExecute (executionCommand);
 

--- a/UnitySoftDebuggerEngine.cs
+++ b/UnitySoftDebuggerEngine.cs
@@ -46,7 +46,7 @@ namespace MonoDevelop.Debugger.Soft.Unity
 			}
 		}
 
-		UnitySoftDebuggerEngine()
+		public UnitySoftDebuggerEngine()
 		{
 			UnityProcessDiscovery.AddLogger (new DebuggerLogger ());
 		}

--- a/UnitySoftDebuggerEngine.cs
+++ b/UnitySoftDebuggerEngine.cs
@@ -26,10 +26,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+
+using System;
 using System.Linq;
 using MonoDevelop.Debugger;
 using MonoDevelop.Core.Execution;
-using Mono.Debugging.Soft;
 using Mono.Debugging.Client;
 
 namespace MonoDevelop.Debugger.Soft.Unity
@@ -38,17 +39,27 @@ namespace MonoDevelop.Debugger.Soft.Unity
 	{
 		UnitySoftDebuggerSession session;
 
-		class DebuggerLogger : UnityProcessDiscovery.ILogger
+		class DebuggerLogger : Log.ILogger
 		{
-			public void Log(string message)
+			public void Info(string message)
 			{
-				DebuggerLoggingService.LogMessage(message);
+				DebuggerLoggingService.LogMessage (message);
+			}
+
+			public void Warning (string message, Exception e)
+			{
+				throw new System.NotImplementedException ();
+			}
+
+			public void Error (string message, Exception e)
+			{
+				DebuggerLoggingService.LogError (message, e);
 			}
 		}
 
 		public UnitySoftDebuggerEngine()
 		{
-			UnityProcessDiscovery.AddLogger (new DebuggerLogger ());
+			Log.AddLogger (new DebuggerLogger ());
 		}
 
 		public override bool CanDebugCommand (ExecutionCommand cmd)

--- a/UnitySoftDebuggerEngine.cs
+++ b/UnitySoftDebuggerEngine.cs
@@ -88,12 +88,4 @@ namespace MonoDevelop.Debugger.Soft.Unity
 	class UnityExecutionCommand : ExecutionCommand
 	{
 	};
-
-	// Allows to define how to setup and tear down connection for debugger to connect to the
-	// debugee. For example to setup TCP tunneling over USB.
-	public interface IUnityDbgConnector
-	{
-		SoftDebuggerStartInfo SetupConnection();
-		void OnDisconnect();
-	}
 }

--- a/UnitySoftDebuggerEngine.cs
+++ b/UnitySoftDebuggerEngine.cs
@@ -68,7 +68,7 @@ namespace MonoDevelop.Debugger.Soft.Unity
 			
 		public override DebuggerSession CreateSession ()
 		{
-			session = new UnitySoftDebuggerSession (UnityProcessDiscovery.ConnectorRegistry);
+			session = new UnitySoftDebuggerSession ();
 			session.TargetExited += delegate{ session = null; };
 			return session;
 		}

--- a/UnitySoftDebuggerEngine.cs
+++ b/UnitySoftDebuggerEngine.cs
@@ -75,7 +75,7 @@ namespace MonoDevelop.Debugger.Soft.Unity
 		
 		public override ProcessInfo[] GetAttachableProcesses ()
 		{
-			return UnityProcessDiscovery.GetAttachableProcesses ().Select (p => new ProcessInfo (p.Id, p.Name)).ToArray();
+			return UnityProcessDiscovery.GetAttachableProcessesAsync ().Select (p => new ProcessInfo (p.Id, p.Name)).ToArray();
 		}
 
 		public string Name {

--- a/UnitySoftDebuggerSession.cs
+++ b/UnitySoftDebuggerSession.cs
@@ -28,19 +28,10 @@
 // THE SOFTWARE.
 
 using System;
-using Mono.Debugger;
-using Mono.Debugging;
 using Mono.Debugging.Soft;
 using Mono.Debugger.Soft;
 using Mono.Debugging.Client;
-using System.Threading;
-using System.Diagnostics;
-using System.IO;
-using MonoDevelop.Core;
-using System.Net.Sockets;
 using System.Net;
-using System.Collections;
-using System.Collections.Generic;
 
 namespace MonoDevelop.Debugger.Soft.Unity
 {
@@ -74,8 +65,8 @@ namespace MonoDevelop.Debugger.Soft.Unity
 				currentConnector = connectorRegistry.Connectors[(uint)processId];
 				StartConnecting(currentConnector.SetupConnection(), 3, 1000);
 				return;
-			} else if (UnitySoftDebuggerEngine.UnityPlayers.ContainsKey ((uint)processId)) {
-				PlayerConnection.PlayerInfo player = UnitySoftDebuggerEngine.UnityPlayers[(uint)processId];
+			} else if (UnityProcessDiscovery.UnityPlayers.ContainsKey ((uint)processId)) {
+				PlayerConnection.PlayerInfo player = UnityProcessDiscovery.UnityPlayers[(uint)processId];
 				int port = (0 == player.m_DebuggerPort
 					? (int)(56000 + (processId % 1000))
 					: (int)player.m_DebuggerPort);

--- a/UnitySoftDebuggerSession.cs
+++ b/UnitySoftDebuggerSession.cs
@@ -40,14 +40,11 @@ namespace MonoDevelop.Debugger.Soft.Unity
 	/// </summary>
 	public class UnitySoftDebuggerSession : SoftDebuggerSession
 	{
-		ConnectorRegistry connectorRegistry;
 		// Connector that was used to make connection for current session.
 		IUnityDbgConnector currentConnector;
 		
-		public UnitySoftDebuggerSession (ConnectorRegistry connectorRegistry)
+		public UnitySoftDebuggerSession ()
 		{
-			this.connectorRegistry = connectorRegistry;
-
 			Adaptor.BusyStateChanged += (object sender, BusyStateEventArgs e) => SetBusyState (e);
 		}
 
@@ -61,27 +58,14 @@ namespace MonoDevelop.Debugger.Soft.Unity
 		
 		protected override void OnAttachToProcess (long processId)
 		{
-			if (connectorRegistry.Connectors.ContainsKey((uint)processId)) {
-				currentConnector = connectorRegistry.Connectors[(uint)processId];
-				StartConnecting(currentConnector.SetupConnection(), 3, 1000);
-				return;
-			} else if (UnityProcessDiscovery.UnityPlayers.ContainsKey ((uint)processId)) {
-				PlayerConnection.PlayerInfo player = UnityProcessDiscovery.UnityPlayers[(uint)processId];
-				int port = (0 == player.m_DebuggerPort
-					? (int)(56000 + (processId % 1000))
-					: (int)player.m_DebuggerPort);
-				try {
-					StartConnecting (new SoftDebuggerStartInfo (new SoftDebuggerConnectArgs (player.m_Id, player.m_IPEndPoint.Address, (int)port)), 3, 1000);
-				} catch (Exception ex) {
-					throw new Exception (string.Format ("Unable to attach to {0}:{1}", player.m_IPEndPoint.Address, port), ex);
-				}
-				return;
-			}
-
-			long defaultPort = 56000 + (processId % 1000);
-			StartConnecting(new SoftDebuggerStartInfo(new SoftDebuggerConnectArgs(null, IPAddress.Loopback, (int)defaultPort)), 3, 1000);
+			StartConnecting (GetUnitySoftDebuggerStartInfo (processId), 3, 1000);
 		}
 
+		public SoftDebuggerStartInfo GetUnitySoftDebuggerStartInfo(long processId)
+		{
+			return UnityProcessDiscovery.GetUnitySoftDebuggerStartInfo (processId, ref currentConnector);
+		}
+			
 		protected override void EndSession ()
 		{
 			Detach ();

--- a/UnitySoftDebuggerSession.cs
+++ b/UnitySoftDebuggerSession.cs
@@ -31,7 +31,6 @@ using System;
 using Mono.Debugging.Soft;
 using Mono.Debugger.Soft;
 using Mono.Debugging.Client;
-using System.Net;
 
 namespace MonoDevelop.Debugger.Soft.Unity
 {
@@ -63,7 +62,8 @@ namespace MonoDevelop.Debugger.Soft.Unity
 
 		public SoftDebuggerStartInfo GetUnitySoftDebuggerStartInfo(long processId)
 		{
-			return UnityProcessDiscovery.GetUnitySoftDebuggerStartInfo (processId, ref currentConnector);
+			var attachInfo = UnityProcessDiscovery.GetUnityAttachInfo (processId, ref currentConnector);
+			return new SoftDebuggerStartInfo (new SoftDebuggerConnectArgs (attachInfo.AppName, attachInfo.Address, attachInfo.Port));
 		}
 			
 		protected override void EndSession ()

--- a/Util.cs
+++ b/Util.cs
@@ -28,8 +28,7 @@
 
 using System;
 using System.IO;
-
-using MonoDevelop.Ide;
+using System.Reflection;
 using MonoDevelop.Core;
 
 namespace MonoDevelop.Debugger.Soft.Unity
@@ -97,7 +96,7 @@ namespace MonoDevelop.Debugger.Soft.Unity
 			// installed side-by-side with Unity.
 			if(string.IsNullOrEmpty(unityLocation) || !File.Exists (unityLocation))
 			{
-				string mdLocation = System.Reflection.Assembly.GetEntryAssembly().Location;
+				string mdLocation = Assembly.GetEntryAssembly().Location;
 
 				string sxsPath = string.Empty;
 				if(Platform.IsMac && mdLocation.Contains ("MonoDevelop.app")) {

--- a/iOSOverUsbSupport.cs
+++ b/iOSOverUsbSupport.cs
@@ -4,7 +4,6 @@ using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Runtime.InteropServices;
-using Mono.Debugging.Client;
 using Mono.Debugging.Soft;
 using MonoDevelop.Core;
 
@@ -352,7 +351,7 @@ namespace MonoDevelop.Debugger.Soft.Unity
 			}
 		}
 
-		public static void GetUSBDevices(ConnectorRegistry connectors, List<ProcessInfo> processes)
+		public static void GetUSBDevices(ConnectorRegistry connectors, List<UnityProcessInfo> processes)
 		{
 			if (!Initialized)
 				return;
@@ -365,7 +364,7 @@ namespace MonoDevelop.Debugger.Soft.Unity
 						var name = GetNameForDevice(device);
 						var processId = connectors.GetProcessIdForUniqueId(device.udid);
 
-						processes.Add(new ProcessInfo(processId, "Unity iOS USB: " + name));
+						processes.Add(new UnityProcessInfo(processId, "Unity iOS USB: " + name));
 						connectors.Connectors[processId] = new iOSUsbConnector(device.udid);
 					}
 				}

--- a/iOSOverUsbSupport.cs
+++ b/iOSOverUsbSupport.cs
@@ -1,11 +1,9 @@
 using System;
-using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Net;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Runtime.InteropServices;
-using Mono.Debugging.Soft;
-using MonoDevelop.Core;
 
 namespace MonoDevelop.Debugger.Soft.Unity
 {
@@ -30,7 +28,6 @@ namespace MonoDevelop.Debugger.Soft.Unity
 			this.udid = udid;
 		}
 	}
-
 
 	static class Usbmuxd
 	{
@@ -301,7 +298,7 @@ namespace MonoDevelop.Debugger.Soft.Unity
 			try {
 				descriptions = LoadDescriptions(path);
 			} catch (Exception e) {
-				LoggingService.LogWarning("Failed to load: " + path, e);
+				Log.Warning("Failed to load: " + path, e);
 				descriptions = new iOSDeviceDescription[0];
 			}
 		}
@@ -315,7 +312,7 @@ namespace MonoDevelop.Debugger.Soft.Unity
 					Usbmuxd.StartUsbmuxdListenThread();
 				return true;
 			} catch (Exception e) {
-				LoggingService.LogWarning("Error while initializing usbmuxd", e);
+				Log.Warning("Error while initializing usbmuxd", e);
 				return false;
 			}
 		}
@@ -368,7 +365,7 @@ namespace MonoDevelop.Debugger.Soft.Unity
 					}
 				}
 			} catch (Exception e) {
-				LoggingService.LogError("Error while getting USB devices", e);
+				Log.Error("Error while getting USB devices", e);
 			}
 		}
 

--- a/iOSOverUsbSupport.cs
+++ b/iOSOverUsbSupport.cs
@@ -14,11 +14,10 @@ namespace MonoDevelop.Debugger.Soft.Unity
 		readonly string udid;
 		readonly ushort port = 12000;
 
-		public SoftDebuggerStartInfo SetupConnection()
+		public UnityAttachInfo SetupConnection()
 		{
 			Usbmuxd.StartIosProxy(port, 56000, udid);
-			var args = new SoftDebuggerConnectArgs(udid, IPAddress.Loopback, port);
-			return new SoftDebuggerStartInfo(args);
+			return new UnityAttachInfo(udid, IPAddress.Loopback, port);
 		}
 
 		public void OnDisconnect()


### PR DESCRIPTION
This is a refactor the debugger add-in to make the Unity process discovery part independent from MonoDevelop. This was done in order to use the Unity process discovery in the Visual Studio Code Unity Debugger Extension: https://github.com/Unity-Technologies/vscode-unity-debug

This change is going in along with upgrading MonoDevelop from 5.9.6 to 5.10.1. The target branch is therefore the MonoDevelop 5.10.1 upgrade branch.
