### PR TITLE
Adds "Unity Hub" to the excluded process names

### DIFF
--- a/UnitySoftDebuggerEngine.cs
+++ b/UnitySoftDebuggerEngine.cs
@@ -157,7 +157,8 @@ namespace MonoDevelop.Debugger.Soft.Unity
 									p.ProcessName.Contains ("Unity.app")) &&
 									!p.ProcessName.Contains ("UnityShader") &&
 									!p.ProcessName.Contains ("UnityHelper") &&
-									!p.ProcessName.Contains ("Unity Helper")) {
+									!p.ProcessName.Contains ("Unity Helper") &&
+									!p.ProcessName.Contains ("Unity Hub")) {
 									unityThreadProcesses.Add (new ProcessInfo (p.Id, string.Format ("{0} ({1})", "Unity Editor", p.ProcessName)));
 								}
 							} catch {


### PR DESCRIPTION
Prevents issues attaching to the Unity process when the Unity Hub is running. ([Hub forum issue](https://forum.unity.com/threads/unity-hub-and-vscode-debug.514908/#post-3373918))