### PR TITLE
Fix attaching to android player

### DIFF
--- a/PlayerConnection.cs
+++ b/PlayerConnection.cs
@@ -72,68 +72,68 @@ namespace MonoDevelop.Debugger.Soft.Unity
                     $" {m_Version} {m_Id}:{m_DebuggerPort} {(m_AllowDebugging ? 1 : 0)}";
             }
 
-			public static Dictionary<string, string> ParsePlayerString(string playerString) {
-				// Remove trailing null character
-				playerString = playerString.TrimEnd('\0');
+            public static Dictionary<string, string> ParsePlayerString(string playerString) {
+                // Remove trailing null character
+                playerString = playerString.TrimEnd('\0');
 
-				// Split string into parts inside [] brackets and after that
-				int partStart = 0;
-				int partLen = 0;
-				List<string> strings = new List<string>();
-				for (int i = 0; i < playerString.Length; i++) {
-					var c = playerString[i];
-					if (c == '[') {
-						partLen = i - partStart;
-						if (partLen > 0) {
-							strings.Add(playerString.Substring(partStart, partLen));
-						}
-						partStart = i + 1;
-					}
-					else if (c == ']') {
-						partLen = i - partStart;
-						if (partLen > 0) {
-							strings.Add(playerString.Substring(partStart, partLen));
-						}
-						partStart = i + 1;
-					}
-				}
+                // Split string into parts inside [] brackets and after that
+                int partStart = 0;
+                int partLen = 0;
+                List<string> strings = new List<string>();
+                for (int i = 0; i < playerString.Length; i++) {
+                    var c = playerString[i];
+                    if (c == '[') {
+                        partLen = i - partStart;
+                        if (partLen > 0) {
+                            strings.Add(playerString.Substring(partStart, partLen));
+                        }
+                        partStart = i + 1;
+                    }
+                    else if (c == ']') {
+                        partLen = i - partStart;
+                        if (partLen > 0) {
+                            strings.Add(playerString.Substring(partStart, partLen));
+                        }
+                        partStart = i + 1;
+                    }
+                }
 
-				partLen = playerString.Length - partStart;
-				if (partLen > 0) {
-					strings.Add(playerString.Substring(partStart, partLen));
-				}
+                partLen = playerString.Length - partStart;
+                if (partLen > 0) {
+                    strings.Add(playerString.Substring(partStart, partLen));
+                }
 
-				// Group key/value pairs
-				Dictionary<string, string> dict = new Dictionary<string, string>();
-				while (strings.Count >= 2) {
-					var key = strings[0].Trim().ToLower();
-					var value = strings[1].Trim();
-					strings.RemoveRange(0, 2);
-					dict[key] = value;
-				}
+                // Group key/value pairs
+                Dictionary<string, string> dict = new Dictionary<string, string>();
+                while (strings.Count >= 2) {
+                    var key = strings[0].Trim().ToLower();
+                    var value = strings[1].Trim();
+                    strings.RemoveRange(0, 2);
+                    dict[key] = value;
+                }
 
-				return dict;
-			}
+                return dict;
+            }
 
-			public static PlayerInfo Parse(string playerString) {
-				var res = new PlayerInfo();
+            public static PlayerInfo Parse(string playerString) {
+                var res = new PlayerInfo();
 
-				try {
-					var playerSettings = ParsePlayerString(playerString);
+                try {
+                    var playerSettings = ParsePlayerString(playerString);
 
-					var ip = playerSettings["ip"];
-					res.m_IPEndPoint = new IPEndPoint(IPAddress.Parse(ip), UInt16.Parse(playerSettings["port"]));
-					res.m_Flags = uint.Parse(playerSettings["flags"]);
-					res.m_Guid = uint.Parse(playerSettings["guid"]);
-					res.m_EditorGuid = uint.Parse(playerSettings["guid"]);
-					res.m_Version = int.Parse(playerSettings["version"]);
-					res.m_Id = playerSettings["id"];
-					res.m_AllowDebugging = 0 != int.Parse(playerSettings["debug"]);
-					if (playerSettings.ContainsKey("debuggerport"))
-						res.m_DebuggerPort = uint.Parse(playerSettings["debuggerport"]);
+                    var ip = playerSettings["ip"];
+                    res.m_IPEndPoint = new IPEndPoint(IPAddress.Parse(ip), UInt16.Parse(playerSettings["port"]));
+                    res.m_Flags = uint.Parse(playerSettings["flags"]);
+                    res.m_Guid = uint.Parse(playerSettings["guid"]);
+                    res.m_EditorGuid = uint.Parse(playerSettings["guid"]);
+                    res.m_Version = int.Parse(playerSettings["version"]);
+                    res.m_Id = playerSettings["id"];
+                    res.m_AllowDebugging = 0 != int.Parse(playerSettings["debug"]);
+                    if (playerSettings.ContainsKey("debuggerport"))
+                        res.m_DebuggerPort = uint.Parse(playerSettings["debuggerport"]);
 
-					Console.WriteLine(res.ToString());
-				}
+                    Console.WriteLine(res.ToString());
+                }
                 catch (Exception e)
                 {
                     throw new ArgumentException("Unable to parse player string", e);


### PR DESCRIPTION
I'm using unity 2017.4.10f1 and I had an issue attaching to android builds from vscode, which used to work previously. Seem's like a PackageName was added to the player string regex.

I replaced the regex with a parsing function to allow for extra/missing parameters to be more compatible with previous/newer versions.

Not sure in which branch to commit this so I based it of the commit used in the vscode unity debugger branch.