### PR TITLE
Catch exception when setting socket options

### DIFF
--- a/PlayerConnection.cs
+++ b/PlayerConnection.cs
@@ -184,9 +184,17 @@ namespace MonoDevelop.Debugger.Soft.Unity
                     multicastSocket.Bind(ipep);
 
                     var ip = IPAddress.Parse(PLAYER_MULTICAST_GROUP);
-                    multicastSocket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership,
-                        new MulticastOption(ip, p.Index));
-                    Log.Info($"Setting up multicast option: {ip}: {port}");
+
+                    try
+                    {
+                        multicastSocket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership,
+                            new MulticastOption(ip, p.Index));
+                        Log.Info($"Setting up multicast option: {ip}: {port}");
+                    }
+                    catch (SocketException e)
+                    {
+                        Log.Error($"Failed to set socket options on adapter {adapter.Id}, address {ip}: {port}", e);
+                    }
                     m_MulticastSockets.Add(multicastSocket);
                 }
             }

--- a/UnityProcessDiscovery.cs
+++ b/UnityProcessDiscovery.cs
@@ -57,7 +57,7 @@ namespace MonoDevelop.Debugger.Soft.Unity
             catch (Exception e)
             {
                 UnityDebug.Log.Write("Error launching player connection discovery service: Unity player discovery will be unavailable");
-                UnityDebug.Log.Write(e.Message);
+                UnityDebug.Log.Write(e.ToString());
                 Log.Error("Error launching player connection discovery service: Unity player discovery will be unavailable", e);
             }
         }


### PR DESCRIPTION
+ print exception trace in addition to message

I encountered that in some cases SetSocketOption() fails for some of the adapters with message:
```
An unknown, invalid, or unsupported option or level was specified in a getsockopt or setsockopt call.
```

While I will try to investigate this, I presume it shouldn't be critical to instantiate `PlayerConnection`.